### PR TITLE
Add script to create and manage Firefox Private Browsing shortcut on Linux

### DIFF
--- a/scripts/firefox-private-window-shortcut/README.md
+++ b/scripts/firefox-private-window-shortcut/README.md
@@ -68,7 +68,7 @@ The Firefox Private Browsing icon is not installed.
 ## Customization
 
 The following can be customized:
-- **Icon URL**: The URL for the Firefox icon is currently set to a Mozilla-specific URL. You can change the URL to any other valid image URL if you prefer a different icon.
+- **Icon URL**: The URL for the Firefox icon is currently set to a Mozilla-specific URL. You can change the URL to any other valid image URL if you prefer a different icon at `ICON_URL`.
 
 The desktop entry file and icon file paths are set to default locations in the script. You can modify the paths by changing the `DESKTOP_FILE` and `ICON_PATH` variables in the script.
 

--- a/scripts/firefox-private-window-shortcut/README.md
+++ b/scripts/firefox-private-window-shortcut/README.md
@@ -1,0 +1,86 @@
+# Firefox Private Browsing Shortcut
+
+This script automates the process of creating and managing a desktop shortcut for launching Firefox in Private Browsing mode. It also allows users to uninstall the shortcut and remove the associated icon if desired.
+
+---
+
+## Features
+
+- **Create a Firefox Private Browsing shortcut**: Installs a shortcut for launching Firefox in Private Browsing mode in the application menu.
+- **Download and set an icon**: Downloads a Firefox icon and associates it with the shortcut.
+- **Uninstall the shortcut and icon**: Allows users to remove the shortcut and the icon associated with it.
+- **Interactive menu**: Provides an easy-to-use menu for installing or uninstalling the shortcut.
+
+---
+
+## Prerequisites
+
+- A Linux-based system.
+- `wget` is required to download the icon image (this is typically pre-installed on most systems).
+
+---
+
+## Installation
+
+1. Clone or download the script to your desired folder.
+
+2. Make the script executable:
+   ```bash
+   chmod +x manage_firefox_shortcut.sh
+   ```
+
+---
+
+## Usage
+
+To run the script and manage the Firefox Private Browsing shortcut, use the following command:
+
+```bash
+./manage_firefox_shortcut.sh
+```
+
+---
+
+## Example Output
+
+When you run the script and select the "Install" option, you should see output like:
+
+```
+Creating the shortcut file...
+Shortcut file created successfully.
+Creating (if it doesn't exist) the icons directory...
+Icons directory created successfully.
+Downloading the shortcut image...
+Shortcut image downloaded successfully.
+Firefox Private Browsing shortcut created successfully!
+You can find it in your application menu.
+```
+
+If you choose the "Uninstall" option, the output will look like:
+
+```
+The Firefox Private Browsing shortcut is not installed.
+The Firefox Private Browsing icon is not installed.
+```
+
+---
+
+## Customization
+
+The following can be customized:
+- **Icon URL**: The URL for the Firefox icon is currently set to a Mozilla-specific URL. You can change the URL to any other valid image URL if you prefer a different icon.
+
+The desktop entry file and icon file paths are set to default locations in the script. You can modify the paths by changing the `DESKTOP_FILE` and `ICON_PATH` variables in the script.
+
+---
+
+## Important Notes
+
+- The script requires the `wget` tool to download the icon. Make sure `wget` is installed on your system.
+- The script assumes the user has Firefox installed on the system.
+
+---
+
+## Contributing
+
+Contributions are welcome! If you have ideas for improvements or new features, feel free to submit a pull request or open an issue.

--- a/scripts/firefox-private-window-shortcut/firefox-private-window-shortcut.md
+++ b/scripts/firefox-private-window-shortcut/firefox-private-window-shortcut.md
@@ -1,0 +1,14 @@
+### [Firefox Private Browsing Shortcut](scripts/firefox-private-window-shortcut)
+
+**Purpose**: This script automates the process of creating and managing a desktop shortcut for launching Firefox in Private Browsing mode. It can also uninstall the shortcut and associated icon if needed.
+
+**Key Features**:  
+- Installs a Firefox Private Browsing shortcut to the application menu.
+- Downloads a Firefox icon for the shortcut.
+- Option to uninstall the shortcut and remove the icon.
+- Interactive menu for easy installation or uninstallation.
+
+**Location**: [scripts/firefox-private-window-shortcut/](scripts/firefox-private-window-shortcut)
+
+**Documentation**:  
+See the `README.md` in the `scripts/firefox-private-window-shortcut` for more details.

--- a/scripts/firefox-private-window-shortcut/firefox-private-window-shortcut.sh
+++ b/scripts/firefox-private-window-shortcut/firefox-private-window-shortcut.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+DESKTOP_FILE=~/.local/share/applications/firefox-private.desktop
+ICON_FOLDER=~/.local/share/icons/
+ICON_PATH=~/.local/share/icons/firefox-private-icon.png
+ICON_URL=https://searchfox.org/mozilla-central/source/browser/branding/nightly/default256.png
+
+create_shortcut() {
+	printf "Creating the shortcut file...\n"
+	touch "$DESKTOP_FILE"
+	chmod +x "$DESKTOP_FILE"
+
+	if [ $? -eq 0 ]; then
+		printf "Shortcut file created successfully.\n"
+	else
+		printf "Failed to create the shortcut file.\n"
+		return 1
+	fi
+
+	printf "Creating (if it doesn't exist) the icons directory...\n"
+	mkdir -p "$ICON_FOLDER"
+
+	if [ $? -eq 0 ]; then
+		printf "Icons directory created successfully.\n"
+	else
+		printf "Failed to create the icons directory.\n"
+		return 1
+	fi
+
+	printf "Downloading the shortcut image...\n"
+	wget -q -O "${ICON_PATH}" "${ICON_URL}"
+
+	if [ $? -eq 0 ]; then
+		printf "Shortcut image downloaded successfully.\n"
+	else
+		printf "Failed to download the shortcut image.\n"
+		return 1
+	fi
+
+	cat <<EOF > "$DESKTOP_FILE"
+[Desktop Entry]
+Version=1.0
+Name=Firefox Private Browsing
+GenericName=Web Browser
+Comment=Browse the web in private mode
+Exec=firefox --private-window %u
+Icon=$ICON_PATH
+Terminal=false
+Type=Application
+Categories=Network;WebBrowser;
+StartupNotify=true
+EOF
+
+	if [ $? -eq 0 ]; then
+		printf "Firefox Private Browsing shortcut created successfully!\n"
+		printf "You can find it in your application menu.\n"
+	else
+		printf "Failed to create the desktop entry file.\n"
+		return 1
+	fi
+}
+
+uninstall_shortcut() {
+	if [ -f "$DESKTOP_FILE" ]; then
+		rm "$DESKTOP_FILE"
+		printf "Firefox Private Browsing shortcut removed successfully!\n"
+	else
+		printf "The Firefox Private Browsing shortcut is not installed.\n"
+	fi
+
+	if [ -f "$ICON_PATH" ]; then
+		rm "$ICON_PATH"
+		printf "The Firefox Private Browsing icon removed successfully!\n"
+	fi
+}
+
+show_menu() {
+	clear
+	echo "=================================="
+	echo "     Firefox Private Browsing     "
+	echo "=================================="
+	echo "1. Install Firefox Private Browsing shortcut"
+	echo "2. Uninstall Firefox Private Browsing shortcut"
+	echo "3. Exit"
+	echo "=================================="
+	read -p "Choose an option: " choice
+	case $choice in
+		1)
+			create_shortcut
+			;;
+		2)
+			uninstall_shortcut
+			;;
+		3)
+			exit 0
+			;;
+		*)
+			echo "Invalid option, please try again."
+			sleep 1
+			show_menu
+			;;
+	esac
+}
+
+show_menu


### PR DESCRIPTION
This PR introduces a script that automates the creation and removal of a **Firefox Private Browsing** shortcut on Linux. The script also downloads an icon for the shortcut and provides an option to uninstall the shortcut and its associated icon if needed.

**What was done:**
- Created a `.desktop` shortcut for Firefox in Private Browsing mode.
- Downloaded and set an icon for the shortcut.
- Added functionality to uninstall the shortcut and icon.
- Interactive menu to easily install or uninstall the shortcut.

---

This PR aims to simplify the creation and management of the Firefox Private Browsing shortcut, especially for users who frequently use Private Browsing.
